### PR TITLE
Updating CI

### DIFF
--- a/.github/aspire-learnings.md
+++ b/.github/aspire-learnings.md
@@ -557,12 +557,75 @@ When creating new Aspire samples by copying from templates:
 
 ---
 
+## 12. PublishWithContainerFiles requires /app/dist in frontend Docker images
+
+**Tags:** aspire, docker, dockerfile, publishwithcontainerfiles, multi-stage-build, ci, omission
+
+### Context
+Using `aspire do build` with `PublishWithContainerFiles()` in the AppHost to copy static frontend files into the API container image.
+
+### What Was Missed
+Frontend Dockerfiles used multi-stage builds that:
+1. Build the frontend in a `node:20` stage at `/app`
+2. Copy only the production output to a `nginx:alpine` stage at `/usr/share/nginx/html`
+
+The final nginx image does NOT contain `/app/dist` - that path only exists in the discarded build stage.
+
+The `PublishWithContainerFiles(frontend, "./wwwroot")` method expects to find files at `/app/dist` in the frontend container.
+
+### Impact
+`aspire do build` fails with:
+```
+ERROR: failed to calculate checksum of ref ... "/app/dist": not found
+```
+
+The API service build step fails because it can't find `/app/dist` in the nginx-based frontend image.
+
+### What Fixed It
+Add an extra COPY instruction in the final Dockerfile stage to keep the dist files at `/app/dist`:
+
+```dockerfile
+FROM nginx:alpine
+
+COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=build /app/dist /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist /app/dist
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+**Note**: Source paths vary by framework:
+- Vite apps (React, Vue, Svelte, Solid, Astro): `/app/dist`
+- Angular: `/app/dist/<projectname>/browser`
+- Next.js: `/app/out`
+- Nuxt: `/app/.output/public`
+
+### Reusable Rule
+When using `PublishWithContainerFiles()` with multi-stage Docker builds:
+1. The frontend Dockerfile MUST have `/app/dist` in the final image
+2. Add a second COPY instruction: `COPY --from=build /app/<source> /app/dist`
+3. This applies to ALL JavaScript frontends using nginx multi-stage builds
+4. The source path depends on the framework's build output location
+5. Add a comment explaining why the duplicate COPY exists
+
+**Search pattern to verify:**
+```bash
+grep -l "PublishWithContainerFiles" **/AppHost.cs
+# For each match, verify the corresponding frontend Dockerfile has /app/dist
+grep "/app/dist$" **/Dockerfile
+```
+
+---
+
 ## Quick Reference Checklist
 
 ### Adding a new JavaScript frontend to Aspire
 
 - [ ] Create unique service names (e.g., `apiservicevue`, `frontendvue`)
 - [ ] Add `Dockerfile` in frontend project
+  - [ ] If using `PublishWithContainerFiles()`, include `/app/dist` in final stage
 - [ ] Add `default.conf.template` for nginx
 - [ ] Choose the right hosting method:
   - **Vite apps (React, Vue, Svelte, Solid)**: Use `AddViteApp()` - PORT handled automatically
@@ -574,7 +637,7 @@ When creating new Aspire samples by copying from templates:
 
 ### CI/CD for Aspire projects
 
-- [ ] Use `dotnet publish /t:PublishContainer` for .NET projects
-- [ ] Use `docker build` for JavaScript frontends
-- [ ] Do NOT use `aspire build` (doesn't exist)
+- [ ] **Aspire 13+**: Use `aspire do build --project <AppHost.csproj>` (preferred)
+- [ ] **Pre-Aspire 13**: Use `dotnet publish /t:PublishContainer` for .NET projects + `docker build` for JavaScript frontends
+- [ ] If using `PublishWithContainerFiles()`, ensure Dockerfiles have `/app/dist` in final stage
 - [ ] Check `AppHost.cs` for `PublishAsDockerFile()` calls

--- a/.github/aspire-learnings.md
+++ b/.github/aspire-learnings.md
@@ -4,37 +4,51 @@ This document contains accumulated learnings from working with .NET Aspire proje
 
 ---
 
-## 1. Aspire CLI does not have a 'build' command - use dotnet publish and docker build for container images
+## 1. Aspire CLI 'aspire do build' command for container images (Aspire 13+)
 
-**Tags:** aspire, ci, build-yml, docker, container, github-actions, dotnet-publish, aspire-cli
+**Tags:** aspire, ci, build-yml, docker, container, github-actions, aspire-cli, aspire-do-build
 
 ### Context
-CI pipeline was using `aspire build` or `aspire do build` commands to build Docker container images for an Aspire-based application with JavaScript frontends.
+CI pipeline needs to build Docker container images for an Aspire-based application with JavaScript frontends.
 
-### What Was Missed
-The Aspire CLI does not have a `build` command. The available commands are:
-- `new` - Create a new Aspire project
-- `init` - Initialize Aspire support
-- `run` - Run in development mode
-- `add` - Add hosting integrations
-- `publish` - Generate deployment artifacts (Preview)
-- `deploy` - Deploy to targets (Preview)
-- `do` - Execute pipeline steps (Preview)
+### Evolution of Aspire CLI Build Support
 
-The `aspire publish` command generates manifests and docker-compose files but does NOT build Docker images.
+**Before Aspire 13:** The Aspire CLI did not have a `build` command. The workaround was:
+- Use `dotnet publish /t:PublishContainer` for .NET projects
+- Use `docker build` for JavaScript frontends
 
-### Impact
-CI pipeline failed with:
-```
-Unrecognized command or argument 'build'.
+**Aspire 13+:** The `aspire do build` command is now available and is the **preferred approach**. It automatically builds all container images defined in the AppHost.
+
+### Current Recommended Approach (Aspire 13+)
+
+Use `aspire do build` with the `--project` parameter pointing to the AppHost:
+
+```bash
+aspire do build --project ./path/to/AppHost.csproj
 ```
 
-### What Fixed It
-Replace `aspire build` with the proper image building approach:
+This command:
+- Automatically discovers all services in the AppHost
+- Builds .NET projects with container support
+- Builds Dockerfiles for JavaScript apps with `PublishAsDockerFile()`
+- Tags images with `:latest` by default
+
+### Example CI Usage
+
+```yaml
+- name: Build container images
+  run: |
+    aspire do build --project "${{ matrix.apphost-dir }}/AppHost.csproj"
+    docker images | head -n 30
+```
+
+### Legacy Approach (Pre-Aspire 13)
+
+If `aspire do build` is not available:
 
 1. **For .NET API projects**: Use `dotnet publish` with container support:
    ```bash
-   dotnet publish "path/to/Project.csproj" -c Release /t:PublishContainer -p:ContainerImageName="imagename" -p:ContainerImageTag="$COMMIT_SHA"
+   dotnet publish "path/to/Project.csproj" -c Release /t:PublishContainer -p:ContainerRepository="imagename" -p:ContainerImageTag="$COMMIT_SHA"
    ```
 
 2. **For JavaScript apps with `PublishAsDockerFile()`**: Build Docker images directly:
@@ -44,11 +58,12 @@ Replace `aspire build` with the proper image building approach:
 
 ### Reusable Rule
 When building container images in CI for Aspire applications:
-1. Do NOT use `aspire build` - it doesn't exist
-2. Use `dotnet publish /t:PublishContainer` for .NET projects
-3. Use `docker build` for JavaScript/Node apps with Dockerfiles
-4. The `aspire publish` command generates deployment manifests, not container images
-5. Check the AppHost.cs for `PublishAsDockerFile()` calls to identify which services need Docker builds
+1. **Aspire 13+**: Use `aspire do build --project <AppHost.csproj>` (preferred)
+2. **Pre-Aspire 13**: Use `dotnet publish /t:PublishContainer` for .NET projects + `docker build` for JavaScript frontends
+3. Images built by `aspire do build` are tagged with `:latest` - retag with commit SHA for versioning if needed
+4. The `--project` parameter must point to the AppHost `.csproj` file
+
+Reference: https://aspire.dev/reference/cli/commands/aspire-do/
 
 ---
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           docker images | head -n 30
 
       - name: Login to GHCR
-        if: ${{ github.ref == 'refs/heads/publish' }}
+        if: ${{ github.ref == 'refs/heads/publish' || github.ref == 'refs/heads/ci-test' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,67 +90,18 @@ jobs:
       - name: Build container images
         run: |
           set -e
-          COMMIT_SHA="${{ github.sha }}"
           
-          # Build the API service container using dotnet publish
-          echo "Building API service container..."
-          if [ "${{ matrix.app }}" = "angular" ]; then
-            API_PROJECT="${{ matrix.app }}/MyAngularApp.api/MyAngularApp.api.csproj"
-            API_IMAGE_NAME="apiserviceangular"
-          elif [ "${{ matrix.app }}" = "vue" ]; then
-            API_PROJECT="${{ matrix.app }}/MyVueApp.api/MyVueApp.api.csproj"
-            API_IMAGE_NAME="apiservicevue"
-          elif [ "${{ matrix.app }}" = "svelte" ]; then
-            API_PROJECT="${{ matrix.app }}/MySvelteApp.api/MySvelteApp.api.csproj"
-            API_IMAGE_NAME="apiservicesvelte"
-          elif [ "${{ matrix.app }}" = "solid" ]; then
-            API_PROJECT="${{ matrix.app }}/MySolidApp.api/MySolidApp.api.csproj"
-            API_IMAGE_NAME="apiservicesolid"
-          elif [ "${{ matrix.app }}" = "astro" ]; then
-            API_PROJECT="${{ matrix.app }}/MyAstroApp.api/MyAstroApp.api.csproj"
-            API_IMAGE_NAME="apiserviceastro"
-          elif [ "${{ matrix.app }}" = "nextjs" ]; then
-            API_PROJECT="${{ matrix.app }}/MyNextJsApp.api/MyNextJsApp.api.csproj"
-            API_IMAGE_NAME="apiservicenextjs"
-          elif [ "${{ matrix.app }}" = "nuxtjs" ]; then
-            API_PROJECT="${{ matrix.app }}/MyNuxtApp.api/MyNuxtApp.api.csproj"
-            API_IMAGE_NAME="apiservicenuxtjs"
-          else
-            API_PROJECT="${{ matrix.app }}/MyReactApp.api/MyReactApp.api.csproj"
-            API_IMAGE_NAME="apiservice"
-          fi
-          dotnet publish "$API_PROJECT" -c Release /t:PublishContainer -p:ContainerRepository="$API_IMAGE_NAME" -p:ContainerImageTag="$COMMIT_SHA"
+          # Get the AppHost project path from the matrix
+          APPHOST_PROJECT="${{ matrix.apphost-dir }}/"
+          # Find the .csproj file in the AppHost directory
+          APPHOST_CSPROJ=$(find "$APPHOST_PROJECT" -maxdepth 1 -name "*.csproj" | head -1)
           
-          # Build the frontend container using Docker
-          echo "Building frontend container..."
-          if [ "${{ matrix.app }}" = "angular" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/myangularapp.web"
-            FRONTEND_IMAGE_NAME="frontendangular"
-          elif [ "${{ matrix.app }}" = "vue" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/myvueapp.web"
-            FRONTEND_IMAGE_NAME="frontendvue"
-          elif [ "${{ matrix.app }}" = "svelte" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/mysvelteapp.web"
-            FRONTEND_IMAGE_NAME="frontendsvelte"
-          elif [ "${{ matrix.app }}" = "solid" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/mysolidapp.web"
-            FRONTEND_IMAGE_NAME="frontendsolid"
-          elif [ "${{ matrix.app }}" = "astro" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/myastroapp.web"
-            FRONTEND_IMAGE_NAME="frontendastro"
-          elif [ "${{ matrix.app }}" = "nextjs" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/mynextjsapp.web"
-            FRONTEND_IMAGE_NAME="frontendnextjs"
-          elif [ "${{ matrix.app }}" = "nuxtjs" ]; then
-            FRONTEND_DIR="${{ matrix.app }}/mynuxtapp.web"
-            FRONTEND_IMAGE_NAME="frontendnuxtjs"
-          else
-            FRONTEND_DIR="${{ matrix.app }}/myreactapp.web"
-            FRONTEND_IMAGE_NAME="frontend"
-          fi
-          docker build -t "$FRONTEND_IMAGE_NAME:$COMMIT_SHA" "$FRONTEND_DIR"
+          echo "Building container images using aspire do build..."
+          echo "AppHost project: $APPHOST_CSPROJ"
           
-          echo "Listing docker images after build";
+          aspire do build --project "$APPHOST_CSPROJ"
+          
+          echo "Listing docker images after build"
           docker images | head -n 30
 
       - name: Login to GHCR
@@ -167,7 +118,7 @@ jobs:
           set -e
           COMMIT_SHA="${{ github.sha }}"
           
-          # Set image names based on matrix app
+          # Set image names based on matrix app (matches service names in AppHost.cs)
           if [ "${{ matrix.app }}" = "angular" ]; then
             API_IMAGE_NAME="apiserviceangular"
             FRONTEND_IMAGE_NAME="frontendangular"
@@ -194,20 +145,23 @@ jobs:
             FRONTEND_IMAGE_NAME="frontend"
           fi
           
+          # aspire do build creates images with :latest tag by default
+          # Tag with commit SHA and push both versions
+          
           # Push API service image
           API_TARGET_REPO="ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}-$API_IMAGE_NAME"
-          echo "Tagging and pushing $API_IMAGE_NAME:$COMMIT_SHA as $API_TARGET_REPO:$COMMIT_SHA"
-          docker tag "$API_IMAGE_NAME:$COMMIT_SHA" "$API_TARGET_REPO:$COMMIT_SHA"
+          echo "Tagging and pushing $API_IMAGE_NAME:latest as $API_TARGET_REPO:$COMMIT_SHA"
+          docker tag "$API_IMAGE_NAME:latest" "$API_TARGET_REPO:$COMMIT_SHA"
           docker push "$API_TARGET_REPO:$COMMIT_SHA"
-          docker tag "$API_IMAGE_NAME:$COMMIT_SHA" "$API_TARGET_REPO:latest"
+          docker tag "$API_IMAGE_NAME:latest" "$API_TARGET_REPO:latest"
           docker push "$API_TARGET_REPO:latest"
           
           # Push frontend image
           FRONTEND_TARGET_REPO="ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}-$FRONTEND_IMAGE_NAME"
-          echo "Tagging and pushing $FRONTEND_IMAGE_NAME:$COMMIT_SHA as $FRONTEND_TARGET_REPO:$COMMIT_SHA"
-          docker tag "$FRONTEND_IMAGE_NAME:$COMMIT_SHA" "$FRONTEND_TARGET_REPO:$COMMIT_SHA"
+          echo "Tagging and pushing $FRONTEND_IMAGE_NAME:latest as $FRONTEND_TARGET_REPO:$COMMIT_SHA"
+          docker tag "$FRONTEND_IMAGE_NAME:latest" "$FRONTEND_TARGET_REPO:$COMMIT_SHA"
           docker push "$FRONTEND_TARGET_REPO:$COMMIT_SHA"
-          docker tag "$FRONTEND_IMAGE_NAME:$COMMIT_SHA" "$FRONTEND_TARGET_REPO:latest"
+          docker tag "$FRONTEND_IMAGE_NAME:latest" "$FRONTEND_TARGET_REPO:latest"
           docker push "$FRONTEND_TARGET_REPO:latest"
           
           echo "Pushed images: $API_TARGET_REPO and $FRONTEND_TARGET_REPO"

--- a/angular/myangularapp.web/Dockerfile
+++ b/angular/myangularapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist/myangularapp.web/browser /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist/myangularapp.web/browser /app/dist
 
 # Expose the default nginx port
 EXPOSE 80

--- a/astro/myastroapp.web/Dockerfile
+++ b/astro/myastroapp.web/Dockerfile
@@ -8,5 +8,7 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist /app/dist
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/nextjs/mynextjsapp.web/Dockerfile
+++ b/nextjs/mynextjsapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/out /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/out /app/dist
 
 # Expose the default nginx port
 EXPOSE 80

--- a/nuxtjs/mynuxtapp.web/Dockerfile
+++ b/nuxtjs/mynuxtapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/.output/public /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/.output/public /app/dist
 
 # Expose the default nginx port
 EXPOSE 80

--- a/react/myreactapp.web/Dockerfile
+++ b/react/myreactapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist /app/dist
 
 # Expose the default nginx port
 EXPOSE 80

--- a/solid/mysolidapp.web/Dockerfile
+++ b/solid/mysolidapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist /app/dist
 
 # Expose the default nginx port
 EXPOSE 80

--- a/svelte/mysvelteapp.web/Dockerfile
+++ b/svelte/mysvelteapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist /app/dist
 
 # Expose the default nginx port
 EXPOSE 80

--- a/vue/myvueapp.web/Dockerfile
+++ b/vue/myvueapp.web/Dockerfile
@@ -15,6 +15,8 @@ FROM nginx:alpine
 
 COPY --from=build /app/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+# Keep dist at /app/dist for Aspire PublishWithContainerFiles
+COPY --from=build /app/dist /app/dist
 
 # Expose the default nginx port
 EXPOSE 80


### PR DESCRIPTION
## Use `aspire do build` for CI container builds

This PR updates the CI pipeline to use the new `aspire do build` command (available in Aspire 13+) instead of manually calling `dotnet publish` and `docker build`. This simplifies the build process and aligns with Aspire's recommended approach.

### Changes

#### CI Pipeline (`build.yml`)
- **Replaced manual container build commands** with `aspire do build --project <AppHost.csproj>`
- **Simplified build step** from ~60 lines of framework-specific logic to ~15 lines
- **Updated image tagging** to work with `aspire do build`'s default `:latest` tag
- **Added `ci-test` branch support** for testing the full pipeline without publishing to GHCR

#### Frontend Dockerfiles (all 8 apps)
- **Added `/app/dist` to final stage** for `PublishWithContainerFiles()` compatibility
- Multi-stage Docker builds now preserve the dist files at `/app/dist` in addition to `/usr/share/nginx/html`
- This fixes the "failed to calculate checksum... /app/dist: not found" error when `aspire do build` tries to copy frontend files into the API container

#### Documentation (`aspire-learnings.md`)
- **Updated Learning #1** to reflect that `aspire do build` is now the preferred approach (Aspire 13+)
- **Added Learning #12** documenting the `PublishWithContainerFiles` requirement for `/app/dist` in multi-stage Dockerfiles
- **Updated Quick Reference Checklists** with current best practices

### Affected Files
- `.github/workflows/build.yml`
- `.github/aspire-learnings.md`
- `angular/myangularapp.web/Dockerfile`
- `react/myreactapp.web/Dockerfile`
- `vue/myvueapp.web/Dockerfile`
- `svelte/mysvelteapp.web/Dockerfile`
- `solid/mysolidapp.web/Dockerfile`
- `astro/myastroapp.web/Dockerfile`
- `nextjs/mynextjsapp.web/Dockerfile`
- `nuxtjs/mynuxtapp.web/Dockerfile`

### Testing
- All 8 app builds pass with `aspire do build` ✅
- `ci-test` branch can be used to test the full pipeline without publishing